### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Detta repo innehåller en komplett lösning för att låta kunder testa om deras
 ## Innehåll
 
 ```
-website/     → Statisk webbsida (HTML/CSS/JS)
+react-website/ → React-baserad webbapp
 checker/     → Python-baserat testprogram & byggscript
 PLAN.md      → Projektplan och tidslinje
 README.md    → Du läser den här
@@ -16,12 +16,12 @@ README.md    → Du läser den här
 ### 1. Webbsidan
 
 ```bash
-# Kör en enkel webbserver (t.ex. Python 3.x)
-python -m http.server --directory website 8000
-# Öppna sedan http://localhost:8000 i webbläsaren
+cd react-website
+npm install
+npm run dev
 ```
 
-Webbsidan är helt statisk och kan publiceras på GitHub Pages, Netlify, Vercel m.m.
+Webbappen byggs med React och Vite och har stöd för mörkt läge via en temaväxlare.
 
 ### 2. Testprogrammet
 

--- a/react-website/postcss.config.js
+++ b/react-website/postcss.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* eslint-disable */
 module.exports = {
   plugins: [
     require('tailwindcss'),

--- a/react-website/src/App.jsx
+++ b/react-website/src/App.jsx
@@ -9,7 +9,7 @@ import ResultsPage from './pages/ResultsPage';
 function App() {
   return (
     <Router>
-      <div className="flex flex-col min-h-screen bg-gray-100">
+      <div className="flex flex-col min-h-screen bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100">
         <Header />
         <div className="flex-grow">
           <Routes>

--- a/react-website/src/components/Header.jsx
+++ b/react-website/src/components/Header.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import ThemeToggle from './ThemeToggle';
 
 function Header() {
   return (
-    <header className="text-center py-6 bg-blue-900 text-white">
+    <header className="text-center py-6 bg-blue-900 text-white dark:bg-gray-800 relative">
+      <div className="absolute right-4 top-4">
+        <ThemeToggle />
+      </div>
       <h1 className="text-3xl font-bold mb-3">Är din dator redo för Windows&nbsp;11?</h1>
       <p className="text-lg mb-2">Fyll i din e-postadress så får du direkt ladda ned vårt testprogram.</p>
       <p className="note italic text-blue-300">Fungerar på både Windows 10 och Windows 11!</p>

--- a/react-website/src/components/ThemeToggle.jsx
+++ b/react-website/src/components/ThemeToggle.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useTheme } from '../theme/ThemeContext';
+
+function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="p-2 rounded text-sm text-gray-600 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700 transition"
+    >
+      {theme === 'dark' ? 'Ljusa läget' : 'Mörka läget'}
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/react-website/src/index.css
+++ b/react-website/src/index.css
@@ -1,12 +1,27 @@
 
 /* Global styles */
+:root {
+  --color-bg: #F2F2F7;
+  --color-bg-secondary: #FFFFFF;
+  --color-text: #1C1C1E;
+  --color-text-secondary: #8A8A8D;
+  --color-primary: #007AFF;
+  --color-primary-hover: #005ECC;
+  --color-border: #C7C7CC;
+}
+
+.dark {
+  --color-bg: #1c1c1e;
+  --color-bg-secondary: #2b2b2f;
+  --color-text: #f2f2f7;
+  --color-text-secondary: #c7c7cc;
+}
 body {
   /* font-family is now handled by Tailwind's 'sans' definition */
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  /* Uses colors defined in tailwind.config.js */
-  color: #1C1C1E;
-  background-color: #F2F2F7;
+  color: var(--color-text);
+  background-color: var(--color-bg);
 }
 
 code {
@@ -25,36 +40,36 @@ code {
   display: block;
   font-size: 0.875rem; /* Consider using Tailwind's text-sm */
   font-weight: 500; /* Consider using Tailwind's font-medium */
-  color: #8A8A8D; /* Updated color */
+  color: var(--color-text-secondary);
   margin-bottom: 0.25rem;
 }
 
 .form-input {
   width: 100%;
   padding: 0.5rem 0.75rem; /* Consider Tailwind's p-2 px-3 */
-  border: 1px solid #C7C7CC; /* Updated border color */
+  border: 1px solid var(--color-border);
   border-radius: 0.375rem; /* Tailwind's rounded-md */
-  background-color: #FFFFFF; /* Ensure input background matches theme */
-  color: #1C1C1E; /* Ensure input text color matches theme */
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text);
   transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out; /* Refined transition */
 }
 .form-input:focus {
   outline: none;
-  border-color: #007AFF; /* Updated focus border color */
+  border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.3); /* Slightly more prominent focus shadow */
 }
 
 .submit-btn {
   padding: 0.625rem 1.25rem; /* Consider Tailwind's py-2.5 px-5 */
   color: #FFFFFF; /* Text on primary button is often white/light */
-  background-color: #007AFF; /* Use primary color */
+  background-color: var(--color-primary);
   border-radius: 0.375rem; /* Tailwind's rounded-md */
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1); /* Subtle shadow */
   font-weight: 500; /* Tailwind's font-medium */
   transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out, transform 0.15s ease-in-out;
 }
 .submit-btn:hover, .submit-btn:focus {
-  background-color: #005ECC; /* Darker shade on hover/tap */
+  background-color: var(--color-primary-hover);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15); /* Enhanced shadow */
   transform: translateY(-1px); /* Subtle lift */
 }
@@ -79,7 +94,7 @@ code {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: #FFFFFF; /* Use theme background */
+  background-color: var(--color-bg-secondary);
   padding: 2rem; /* Consider Tailwind's p-8 */
   border-radius: 14px; /* iOS like rounded corners for modals */
   max-width: 850px;
@@ -87,28 +102,28 @@ code {
   max-height: 85vh;
   overflow-y: auto;
   z-index: 1001;
-  color: #1C1C1E; /* Use theme text color */
+  color: var(--color-text);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12); /* More subtle iOS-like shadow */
 }
 
 .info-modal h2 {
-  color: #007AFF; /* Use primary color for headings */
+  color: var(--color-primary);
   margin-bottom: 1.5rem;
   font-size: 1.75rem; /* Consider Tailwind's text-2xl or text-3xl */
   text-align: center;
 }
 
 .info-modal h3 {
-  color: #1C1C1E;
+  color: var(--color-text);
   margin-top: 1.5rem;
   margin-bottom: 1rem;
   font-size: 1.25rem; /* Consider Tailwind's text-xl */
-  border-bottom: 1px solid #C7C7CC; /* Use theme border color */
+  border-bottom: 1px solid var(--color-border);
   padding-bottom: 0.5rem;
 }
 
 .info-modal h4 {
-  color: #007AFF;
+  color: var(--color-primary);
   margin-bottom: 0.5rem;
   font-size: 1.1rem; /* Consider Tailwind's text-lg */
   font-weight: 600; /* Tailwind's font-semibold */
@@ -122,14 +137,14 @@ code {
   background: none;
   border: none;
   cursor: pointer;
-  color: #8A8A8D;
+  color: var(--color-text-secondary);
   transition: color 0.2s ease-in-out, transform 0.15s ease-in-out;
   padding: 0.25rem; /* Add some padding to make the click target slightly larger */
   border-radius: 4px; /* Add a slight radius for visual consistency if it ever gets a background */
 }
 
 .info-modal-close-button:hover, .info-modal-close-button:focus {
-  color: #1C1C1E;
+  color: var(--color-text);
   transform: scale(1.1); /* Slight zoom effect */
   outline: none; /* Remove default focus outline if custom styling is clear */
 }
@@ -480,13 +495,13 @@ code {
 }
 
 .submit-btn:hover { /* This is less specific than the one with :focus and :active combined */
-  background-color: #005ECC;
+  background-color: var(--color-primary-hover);
   /* transform: translateY(-1px); Ensure this is consistent with other .submit-btn:hover */
   /* box-shadow: ... ensure consistency */
 }
 
 .submit-btn:disabled {
-  background-color: #8E8E93; /* Use themed disabled color */
+  background-color: var(--color-text-secondary);
   cursor: not-allowed;
   opacity: 0.7; /* Common practice for disabled state */
 }
@@ -502,7 +517,7 @@ code {
   max-width: 800px;
   margin: 2rem auto; /* Added top/bottom margin */
   padding: 2rem; /* Tailwind p-8 */
-  background-color: #FFFFFF; /* Themed background */
+  background-color: var(--color-bg-secondary);
   border-radius: 12px; /* iOS like rounded corners */
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.07); /* Softer shadow */
 }
@@ -511,7 +526,7 @@ code {
   font-size: 1.8rem; /* Consider text-3xl */
   font-weight: 600; /* font-semibold */
   margin-bottom: 1.5rem;
-  color: #1C1C1E;
+  color: var(--color-text);
   text-align: center;
 }
 
@@ -519,14 +534,14 @@ code {
   font-size: 1.4rem; /* Consider text-2xl */
   font-weight: 500; /* font-medium */
   margin-bottom: 1rem;
-  color: #8A8A8D;
+  color: var(--color-text-secondary);
 }
 
 .results-message {
   font-size: 1.1rem; /* Consider text-lg */
   line-height: 1.6;
   margin-bottom: 1.5rem;
-  color: #1C1C1E;
+  color: var(--color-text);
 }
 
 .requirement {
@@ -551,7 +566,7 @@ code {
 
 .requirement-text {
   flex: 1;
-  color: #1C1C1E;
+  color: var(--color-text);
 }
 
 .check-icon {

--- a/react-website/src/main.jsx
+++ b/react-website/src/main.jsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { ThemeProvider } from './theme/ThemeContext'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )

--- a/react-website/src/theme/ThemeContext.jsx
+++ b/react-website/src/theme/ThemeContext.jsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext({ theme: 'light', toggleTheme: () => {} });
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('theme');
+      if (stored) return stored;
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);

--- a/react-website/tailwind.config.js
+++ b/react-website/tailwind.config.js
@@ -1,5 +1,8 @@
+/* eslint-env node */
+/* eslint-disable */
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- modernize README instructions
- add theme context and toggle components
- wrap app with ThemeProvider
- support dark mode styles

## Testing
- `npm run lint`
- `python test_checker.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_b_6840a349c184832c8696aecb728e2254