### PR TITLE
Add side info boxes with overlay on homepage

### DIFF
--- a/react-website/src/components/Overlay.jsx
+++ b/react-website/src/components/Overlay.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+function Overlay({ title, onClose, children }) {
+  return (
+    <>
+      <div className="modal-overlay" onClick={onClose}></div>
+      <aside className="info-modal" role="dialog" aria-modal="true">
+        <button className="info-modal-close-button" onClick={onClose} aria-label="Stäng">×</button>
+        {title && <h2>{title}</h2>}
+        <div className="overlay-content text-left space-y-4">{children}</div>
+      </aside>
+    </>
+  );
+}
+
+export default Overlay;

--- a/react-website/src/components/SideInfoBox.jsx
+++ b/react-website/src/components/SideInfoBox.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import Overlay from './Overlay';
+
+function SideInfoBox({ position = 'left', title, summary, hoverInfo, details }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <div
+        className={
+          `group side-info-box-inner w-60 p-4 bg-white dark:bg-gray-800 shadow-lg rounded-lg cursor-pointer transform transition hover:-translate-y-1` +
+          (position === 'left' ? ' text-left' : ' text-right')
+        }
+        onClick={() => setOpen(true)}
+      >
+        <h3 className="text-lg font-semibold mb-1">{title}</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-300">{summary}</p>
+        {hoverInfo && (
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 hidden group-hover:block">
+            {hoverInfo}
+          </p>
+        )}
+      </div>
+      {open && (
+        <Overlay title={title} onClose={() => setOpen(false)}>
+          {details}
+        </Overlay>
+      )}
+    </>
+  );
+}
+
+export default SideInfoBox;

--- a/react-website/src/index.css
+++ b/react-website/src/index.css
@@ -446,3 +446,13 @@ code {
   color: #FF3B30; /* Themed icon color */
   font-size: 1.5rem;
 }
+
+/* Overlay generic content area */
+.overlay-content {
+  margin-top: 1rem;
+}
+
+.side-info-box-inner {
+  backdrop-filter: blur(2px);
+}
+

--- a/react-website/src/pages/HomePage.jsx
+++ b/react-website/src/pages/HomePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import EmailForm from '../components/EmailForm';
 import InfoModal from '../components/InfoModal';
+import SideInfoBox from '../components/SideInfoBox';
 
 function HomePage() {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -14,28 +15,41 @@ function HomePage() {
   };
 
   return (
-    // Centrera allt innehåll och lägg till mer vertikal padding
-    <main className="container mx-auto px-4 py-12 md:py-16 text-center">
-      {/* Textsektion */}
-      <div className="mb-10 md:mb-12">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-800 dark:text-white mb-4">
-          Är din dator redo för Windows 11?
-        </h1>
-        <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300 mb-2 max-w-2xl mx-auto">
-          Fyll i din e-postadress så får du direkt ladda ned vårt testprogram.
-        </p>
-        <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
-          Fungerar på både Windows 10 och Windows 11!
-        </p>
+    <main className="relative container mx-auto px-4 py-12 md:py-16 flex justify-center">
+      <div className="max-w-xl w-full bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 sm:p-8 text-center">
+        <div className="mb-8">
+          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gray-800 dark:text-white mb-4">
+            Är din dator redo för Windows 11?
+          </h1>
+          <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300 mb-2">
+            Fyll i din e-postadress så får du direkt ladda ned vårt testprogram.
+          </p>
+          <p className="text-base sm:text-lg text-gray-600 dark:text-gray-300">
+            Fungerar på både Windows 10 och Windows 11!
+          </p>
+        </div>
+        <EmailForm onInfoButtonClick={handleInfoButtonClick} />
+        <InfoModal show={isModalOpen} onClose={handleCloseModal} />
       </div>
 
-      {/* Formulär-kort sektion */}
-      {/* Behåll max-w-3xl här för att kortet inte ska bli för brett, men texten ovan kan vara bredare */}
-      <div className="max-w-xl mx-auto"> 
-        <div className="form-container bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 sm:p-8">
-          <EmailForm onInfoButtonClick={handleInfoButtonClick} />
-          <InfoModal show={isModalOpen} onClose={handleCloseModal} />
-        </div>
+      <div className="hidden md:block absolute top-1/4" style={{ left: '-18rem' }}>
+        <SideInfoBox
+          position="left"
+          title="Varför testa?"
+          summary="Snabb koll på systemet."
+          hoverInfo="Kontrollen visar om din dator klarar Windows 11."
+          details={<p>Att testa i förväg hjälper dig planera för uppgraderingen och undvika överraskningar.</p>}
+        />
+      </div>
+
+      <div className="hidden md:block absolute top-1/4" style={{ right: '-18rem' }}>
+        <SideInfoBox
+          position="right"
+          title="Om verktyget"
+          summary="Så fungerar programmet."
+          hoverInfo="Håll musen här för mer info."
+          details={<p>Programmet läser av grundläggande hårdvaruinformation och sparar endast det allra nödvändigaste.</p>}
+        />
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- center homepage content within a modern card
- add floating SideInfoBox components with overlays
- implement reusable Overlay component for modal content
- refine styling in `index.css`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python test_checker.py` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_684153a37ecc832cb95060d4645a5bc6