### PR TITLE
Fix tailwind css directives

### DIFF
--- a/react-website/src/index.css
+++ b/react-website/src/index.css
@@ -1,3 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* Global styles */
 :root {


### PR DESCRIPTION
## Summary
- add Tailwind base/components/utilities imports to index.css so styling loads

## Testing
- `python test_checker.py` *(fails: ModuleNotFoundError: No module named 'psutil')*

------
https://chatgpt.com/codex/tasks/task_b_684155847420832c8a3633ac86f157d6