### PR TITLE
Fix PostCSS plugin usage

### DIFF
--- a/react-website/postcss.config.cjs
+++ b/react-website/postcss.config.cjs
@@ -1,8 +1,8 @@
 /* eslint-env node */
 /* eslint-disable */
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('@tailwindcss/postcss'),
+    require('autoprefixer'),
+  ],
 };


### PR DESCRIPTION
## Summary
- restore @tailwindcss/postcss plugin use in PostCSS config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6841594ae790832ca95292e1b9dd7e99