### PR TITLE
Allow configuring API/base URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ python checker.py
 # Bygg en portabel exe-fil (kräver Windows & PyInstaller)
 build.bat
 ```
+Vill du peka programmet mot en egen server kan du ange URL:erna via
+miljövariabler eller flaggor:
+
+```bash
+# med miljövariabler
+API_URL=https://example.com/api BASE_URL=https://myhost python checker.py
+
+# eller med flaggor
+python checker.py --api-url https://example.com/api \
+                  --base-url https://myhost
+```
 
 `dist/checker.exe` kan därefter signeras och delas med kunderna.
 


### PR DESCRIPTION
## Summary
- let checker URLs be overridden via environment variables or CLI flags
- document the new config in the README

## Testing
- `python -m py_compile checker/checker.py`

------
https://chatgpt.com/codex/tasks/task_b_6841599034c4832cb03e6f4324851e3e